### PR TITLE
Bumped version of pivotal-tracker gem and changed link to view in Pivotal Tracker

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,4 +8,4 @@ gem 'shotgun'
 gem 'thin'
 
 gem 'json'
-gem 'pivotal-tracker', '>= 0.1.3'
+gem 'pivotal-tracker', '>= 0.3.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: http://rubygems.org/
   specs:
-    builder (2.1.2)
+    builder (3.0.0)
     daemons (1.1.0)
     eventmachine (0.12.10)
     haml (3.0.16)
@@ -12,13 +12,13 @@ GEM
     mime-types (1.16)
     mustache (0.11.2)
     nokogiri (1.4.3.1)
-    pivotal-tracker (0.2.0)
+    pivotal-tracker (0.3.1)
       builder
-      happymapper (>= 0.2.4)
-      nokogiri (~> 1.4.1)
-      rest-client (~> 1.5.1)
+      happymapper (>= 0.3.2)
+      nokogiri (~> 1.4.3.1)
+      rest-client (~> 1.6.0)
     rack (1.2.1)
-    rest-client (1.5.1)
+    rest-client (1.6.1)
       mime-types (>= 1.16)
     shotgun (0.8)
       rack (>= 1.0)
@@ -36,7 +36,7 @@ DEPENDENCIES
   haml
   json
   mustache
-  pivotal-tracker (>= 0.1.3)
+  pivotal-tracker (>= 0.3.1)
   shotgun
   sinatra
   thin

--- a/dev/views/index.haml
+++ b/dev/views/index.haml
@@ -6,5 +6,12 @@
   %body
     bodily
     Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur eget nisi eget turpis sodales interdum et vel sem. Suspendisse potenti. Nullam convallis lacinia leo at elementum. Quisque mi ante, egestas id accumsan ut, tempor vel erat. Cras placerat sapien non mi cursus egestas. Nulla at odio in ipsum fermentum posuere id sit amet nisi. Phasellus id mi dui, vitae posuere turpis. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Mauris bibendum, justo eget adipiscing imperdiet, neque dolor cursus velit, at tristique nunc erat venenatis dui. Integer ut diam velit, vitae tincidunt metus. Integer mattis adipiscing convallis. Aenean dapibus scelerisque nisi et semper. Ut luctus nisl a nulla porttitor a feugiat risus pulvinar. Nam ut quam ut ipsum faucibus auctor tempus ut diam. Donec facilisis, nunc faucibus faucibus congue, metus justo sagittis nibh, vitae mollis nisl eros quis orci. Ut tincidunt, nisl sed vulputate condimentum, sem lectus elementum tortor, eu pharetra enim massa id justo. Donec non libero eget ligula laoreet imperdiet sed sit amet diam.
-
+    %br
+    %br
+    %div
+      Project ID:
+      = Whereuat.configuration.pivotal_tracker_project
+    %div
+      Token:
+      = Whereuat.configuration.pivotal_tracker_token
     = whereuat

--- a/lib/whereuat/templates/index.haml
+++ b/lib/whereuat/templates/index.haml
@@ -5,7 +5,7 @@
       %li
         %a.wua-accept{:href => "#accept", :title => "accept"} accept
         %a.wua-reject{:href => "#reject", :title => "reject"} reject
-        %a.wua-pivotal{:href => story.url, :title => "View in Pivotal Tracker"} View in Pivotal Tracker
+        %a.wua-pivotal{:href => story.url, :title => "View in Pivotal Tracker", :target => "pivotal_tracker"} View in Pivotal Tracker
         %span.wua-story= story.name
         %span.wua-story-id.wua-hide= story.id
         %form.wua-hide


### PR DESCRIPTION
I upped the version of the pivotal-tracker gem to 0.3.1 from 0.1.3 to use the latest rest-client (I was having bundler conflicts when it tried to include chef's soloist in my project. 

Also changed the link to View in Pivotal Tracker to open a new named tab. The usage I see is that people want to stay on that page in my site, but also crack open Tracker to see the details. Since it is named, no matter how many times they go to click on that link it'll only open one window. 

P.S. We'll be using this on StageIt in our staging environment so that our QA people know what to accept. This is perfect for our work flow. Thanks!
