### PR TITLE
Add ssl option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ tmtags
 ## VIM
 *.swp
 
+## RUBYMINE
+.idea
+
 ## PROJECT::GENERAL
 coverage
 rdoc

--- a/README.md
+++ b/README.md
@@ -17,7 +17,13 @@ Create an initializer to add the Whereuat::RackApp to your middleware stack and 
     Whereuat.configure do |config|
       config.pivotal_tracker_token   = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
       config.pivotal_tracker_project = 123456
+      config.pivotal_tracker_use_ssl = false
     end
+
+You can find or create a Pivotal Tracker api token by going to your profile page on Pivotal Tracker.
+Your project ID can be found by looking at the url of your project. It will look like:
+
+    www.pivotaltracker.com/projects/:project_id
 
 Use the following helper somewhere in your application layout (we recommend at the end of the body):
 

--- a/Rakefile
+++ b/Rakefile
@@ -45,12 +45,16 @@ if rake_app.top_level_tasks.include?('dev')
         puts "What pivotal tracker project do you want to test against? (e.g. The digits at the end of http://www.pivotaltracker.com/projects/12345)."
         project_id = $stdin.gets.chomp
 
+        puts "Does your project use SSL or not? (true/false)"
+        use_ssl = $stdin.gets.chomp
+
         puts "Creating config using your details."
 
         pivotal_config.open('w') {|f|
           f << %{Whereuat.configure do |config|
                   config.pivotal_tracker_token   = "#{token}"
                   config.pivotal_tracker_project = #{project_id}
+                  config.pivotal_tracker_use_ssl = #{use_ssl}
                 end
           }.gsub(/^\s{3,16}/,'')
         }

--- a/lib/whereuat/configuration.rb
+++ b/lib/whereuat/configuration.rb
@@ -2,5 +2,6 @@ module Whereuat
   class Configuration
     attr_accessor :pivotal_tracker_token
     attr_accessor :pivotal_tracker_project
+    attr_accessor :pivotal_tracker_use_ssl
   end
 end

--- a/lib/whereuat/rack_app.rb
+++ b/lib/whereuat/rack_app.rb
@@ -11,6 +11,7 @@ module Whereuat
     def initialize(app)
       @app             = app
       PT::Client.token = config.pivotal_tracker_token
+      PT::Client.use_ssl = config.pivotal_tracker_use_ssl
     end
 
     def call(env)


### PR DESCRIPTION
Hi,

My Pivotal Tracker projects have the use SSL option enabled so I cannot use whereuat without this patch.

I couldn't find any tests to add to so I didn't add any :(

I tried to test using `rake dev` but I kept getting a boot error because it couldn't load dev.rb. Instead, I just added my local gem path to the app I was trying to use whereuat with and verified that it worked.

Before this feature, while using my app I was getting a 400 error on the request when you click the whereuat tab. Now, it loads up my stories as expected when I set pivotal_tracker_use_ssl to true.

Let me know if you need any other changes made, but this works great!

Thanks,

Jake
